### PR TITLE
Do not install the default ssh config by default

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -66,10 +66,7 @@ case ${answer:0:1} in
     fi
   ;;
   * )
-    # Symlink the ssh config file.
-    if [ ! -L $SSH_DIR/config ]; then
-      ln -s $DOTFILES_DIR/ssh/config $SSH_DIR/config
-    fi
+    echo "The default ssh config was not installed."
 esac
 
 if [ $(uname) == "Darwin" ]; then


### PR DESCRIPTION
The default ssh config was being installed for every option. Now it echos a message.